### PR TITLE
Fix typo for number of functions hits

### DIFF
--- a/lib/src/models/enum.dart
+++ b/lib/src/models/enum.dart
@@ -4,7 +4,7 @@ enum LineType {
   FN,
   FNDA,
   FNF,
-  FHN,
+  FNH,
   BRDA,
   BRF,
   BRH,

--- a/lib/src/transformer.dart
+++ b/lib/src/transformer.dart
@@ -33,7 +33,7 @@ class Transformer {
       case LineType.FNF:
         record.functions!.found = int.parse(line.data[0]);
         break;
-      case LineType.FHN:
+      case LineType.FNH:
         record.functions!.hit = int.parse(line.data[0]);
         break;
       case LineType.BRDA:

--- a/test/parse_line_test.dart
+++ b/test/parse_line_test.dart
@@ -9,7 +9,7 @@ void main() {
     expect(toLineType('FN'), LineType.FN);
     expect(toLineType('FNDA'), LineType.FNDA);
     expect(toLineType('FNF'), LineType.FNF);
-    expect(toLineType('FHN'), LineType.FHN);
+    expect(toLineType('FNH'), LineType.FNH);
     expect(toLineType('BRDA'), LineType.BRDA);
     expect(toLineType('BRF'), LineType.BRF);
     expect(toLineType('BRH'), LineType.BRH);

--- a/test/transformer_test.dart
+++ b/test/transformer_test.dart
@@ -74,7 +74,7 @@ void main() {
   });
 
   test('Should transform LineType.FHN', () {
-    final line = Line(type: LineType.FHN, data: data);
+    final line = Line(type: LineType.FNH, data: data);
     final record = Record.empty();
 
     expect(record.functions!.hit, null);


### PR DESCRIPTION
Appears to be a typo with the `FNH` , lcov.info files with this token get a parse error

@eliasreis54 